### PR TITLE
Drop dependency on zope.location, again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='node',
       zip_safe=True,
       install_requires=[
           'setuptools',
-          'zope.location',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
I've run the tests, things are ok, we don't need zope.location in node.
